### PR TITLE
(Feat:po notes tables)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.6",
         "@mui/styled-engine-sc": "^5.11.0",
+        "@mui/system": "^5.11.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-query": "^3.39.2",
@@ -3547,12 +3548,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.11.2.tgz",
-      "integrity": "sha512-qZwMaqRFPwlYmqwVKblKBGKtIjJRAj3nsvX93pOmatsXyorW7N/0IPE/swPgz1VwChXhHO75DwBEx8tB+aRMNg==",
+      "version": "5.11.7",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.11.7.tgz",
+      "integrity": "sha512-XzRTSZdc8bhuUdjablTNv3kFkZ/XIMlKkOqqJCU0G8W3tWGXpau2DXkafPd1ddjPhF9zF3qLKNGgKCChYItjgA==",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
-        "@mui/utils": "^5.11.2",
+        "@mui/utils": "^5.11.7",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3629,15 +3630,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.11.5",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.11.5.tgz",
-      "integrity": "sha512-KNVsJ0sgRRp2XBqhh4wPS5aacteqjwxgiYTVwVnll2fgkgunZKo3DsDiGMrFlCg25ZHA3Ax58txWGE9w58zp0w==",
+      "version": "5.11.7",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.11.7.tgz",
+      "integrity": "sha512-uGB6hBxGlAdlmbLdTtUZYNPXkgQGGnKxHdkRATqsu7UlCxNsc/yS5NCEWy/3c4pnelD1LDLD39WrntP9mwhfkQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
-        "@mui/private-theming": "^5.11.2",
+        "@mui/private-theming": "^5.11.7",
         "@mui/styled-engine": "^5.11.0",
         "@mui/types": "^7.2.3",
-        "@mui/utils": "^5.11.2",
+        "@mui/utils": "^5.11.7",
         "clsx": "^1.2.1",
         "csstype": "^3.1.1",
         "prop-types": "^15.8.1"
@@ -3681,9 +3682,9 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.11.2.tgz",
-      "integrity": "sha512-AyizuHHlGdAtH5hOOXBW3kriuIwUIKUIgg0P7LzMvzf6jPhoQbENYqY6zJqfoZ7fAWMNNYT8mgN5EftNGzwE2w==",
+      "version": "5.11.7",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.11.7.tgz",
+      "integrity": "sha512-8uyNDeVHZA804Ego20Erv8TpxlbqTe/EbhTI2H1UYr4/RiIbBprat8W4Qqr2UQIsC/b3DLz+0RQ6R/E5BxEcLA==",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "@types/prop-types": "^15.7.5",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.6",
     "@mui/styled-engine-sc": "^5.11.0",
+    "@mui/system": "^5.11.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-query": "^3.39.2",
     "react-router-dom": "^6.7.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6",
-    "web-vitals": "^2.1.4",
-    "react-query": "^3.39.2"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -42,6 +43,9 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
     "eslint": "^8.32.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.6.0",
@@ -49,10 +53,7 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.32.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "prettier": "^2.8.3",
     "jest": "^27.5.1",
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0"
+    "prettier": "^2.8.3"
   }
 }

--- a/src/components/Theme/globalTheme.js
+++ b/src/components/Theme/globalTheme.js
@@ -1,0 +1,50 @@
+/* eslint-disable import/no-import-module-exports */
+
+import { createTheme } from '@mui/material/styles';
+
+// Theme for the PO Notes Tables Header
+const PONotesTableTheme = createTheme({
+    components: {
+        MuiTypography: {
+            variants: [
+                {
+                    props: { variant: 'h6' },
+                    style: {
+                        color: 'white',
+                        fontFamily: 'Roboto',
+                        display: 'flow',
+                        lineHeight: '22px'
+                    },
+                },
+
+            ],
+        },
+        // theme for the PO Notes tables header
+        MuiTableCell: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: '#051C2C',
+                    borderradius: '0px', color: '#FFFFFF'
+                },
+            },
+        },
+        //  theme for the PO Notes tables container
+        MuiTableContainer: {
+            styleOverrides: {
+                root:
+                {
+                    background: '#EEF2F5',
+                    height: '725px',
+                    maxHeight: '1000px',
+                    Width: '500px',
+                    width: '100%',
+                    flexGrow: -5
+                },
+            },
+        },
+    }
+
+});
+
+
+export default PONotesTableTheme;

--- a/src/components/poNotesComponents/PONotesTables/ActionItemsTable.js
+++ b/src/components/poNotesComponents/PONotesTables/ActionItemsTable.js
@@ -1,0 +1,39 @@
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Paper
+} from '@mui/material'
+import React from 'react'
+import Box from '@mui/material/Box';
+import { ThemeProvider } from '@mui/material/styles';
+import ActionItemsTableHeader from './PONotesTablesHeader/ActionItemsTableHeader'
+import PONotesTableTheme from '../../Theme/globalTheme'
+
+
+// table for the action items
+export default function ActionItemsTable() {
+  return (
+    <Box sx={{ width: '600px' }}>
+      <ThemeProvider theme={PONotesTableTheme}>
+        <TableContainer component={Paper}>
+          <Table stickyHeader aria-label='simple table'>
+            <TableHead>
+              <TableRow align='center'>
+                {/* calling the action item table header and passing count of action items in the table as props in countOfItems variable */}
+                <TableCell><ActionItemsTableHeader countOfItems={0} /></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody >
+              <TableRow />
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </ThemeProvider>
+    </Box>
+
+  )
+}

--- a/src/components/poNotesComponents/PONotesTables/AgendaItemsTable.js
+++ b/src/components/poNotesComponents/PONotesTables/AgendaItemsTable.js
@@ -1,0 +1,39 @@
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Paper
+} from '@mui/material'
+import React from 'react'
+import Box from '@mui/material/Box';
+import { ThemeProvider } from '@mui/material/styles';
+import AgendaItemsTableHeader from './PONotesTablesHeader/AgendaItemsTableHeader'
+import PONotesTableTheme from '../../Theme/globalTheme'
+
+
+// table for the action items
+export default function ActionItemsTable() {
+  return (
+    <Box sx={{ width: '600px' }}>
+      <ThemeProvider theme={PONotesTableTheme}>
+        <TableContainer component={Paper}>
+          <Table stickyHeader aria-label='simple table'>
+            <TableHead>
+              <TableRow align='center'>
+                {/* calling the action item table header and passing count of action items in the table as props in countOfItems variable */}
+                <TableCell><AgendaItemsTableHeader countOfItems={0} /></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody >
+              <TableRow />
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </ThemeProvider>
+    </Box>
+
+  )
+}

--- a/src/components/poNotesComponents/PONotesTables/KeyDecisionsTable.js
+++ b/src/components/poNotesComponents/PONotesTables/KeyDecisionsTable.js
@@ -1,0 +1,38 @@
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Paper
+} from '@mui/material'
+import React from 'react'
+import Box from '@mui/material/Box';
+import { ThemeProvider } from '@mui/material/styles';
+import KeyDecisionsTableHeader from './PONotesTablesHeader/KeyDecisionsTableHeader'
+import PONotesTableTheme from '../../Theme/globalTheme'
+
+// table for the action items
+export default function KeyDecisionsTable() {
+  return (
+    <Box sx={{ width: '600px' }}>
+      <ThemeProvider theme={PONotesTableTheme}>
+        <TableContainer component={Paper}>
+          <Table stickyHeader aria-label='simple table'>
+            <TableHead>
+              <TableRow align='center'>
+                {/* calling the action item table header and passing count of action items in the table as props in countOfItems variable */}
+                <TableCell><KeyDecisionsTableHeader countOfItems={0} /></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody >
+              <TableRow />
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </ThemeProvider>
+    </Box>
+
+  )
+}

--- a/src/components/poNotesComponents/PONotesTables/PONotesGridLayout.js
+++ b/src/components/poNotesComponents/PONotesTables/PONotesGridLayout.js
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import Grid from '@mui/material/Grid';
+import ActionItemsTable from './ActionItemsTable';
+import KeyDecisionTable from './KeyDecisionsTable';
+import AgendaItemsTable from './AgendaItemsTable';
+
+export default function PONotesGridLayout() {
+  return (
+    // using grid to layout the tables and making it responsive
+    <Grid container spacing={5} columns={20}>
+      <Grid item xs='auto' > </Grid>
+      {/* grid for action items table */}
+      <Grid sx={{
+        p: 6,
+        m: 1,
+        display: 'flex',
+        flexDirection: 'row'
+      }} item xs={6}>
+        <ActionItemsTable />
+      </Grid>
+       {/* grid for key decisions table */}
+      <Grid sx={{
+        p: 6,
+        m: 1,
+        display: 'flex',
+        flexDirection: 'row'
+      }} item xs={6}>
+        <KeyDecisionTable />
+      </Grid>
+       {/* grid for agenda items table */}
+      <Grid sx={{
+        p: 6,
+        m: 1,
+        display: 'flex',
+        flexDirection: 'row'
+      }} item xs={6}>
+        <AgendaItemsTable />
+      </Grid>
+      <Grid item xs='auto'> </Grid>
+    </Grid>
+  );
+}
+
+
+
+
+
+
+
+
+

--- a/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/ActionItemsTableHeader.js
+++ b/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/ActionItemsTableHeader.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Typography } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import PropTypes from 'prop-types';
+import PONotesInformationModel from './PONotesInformationModel'
+import PONotesTableTheme from '../../../Theme/globalTheme'
+
+export default function ActionItemsHeader(props) {
+  // countOfItems is the number of items in the table
+  const { countOfItems } = props;
+  // heading is the heading of the information model
+  const heading = 'Action Items';
+  // definition is the definition of the information model
+  const definition = ' are the tasks that the Product Owner(PO) has to do in order to unblock the team, and can be linked to an issue in the Project management tool such as Jira.';
+  // accessibiltyInformation is the accessibility information of the information model
+  const accessibiltyInformation = 'PO is the owner of this section only PO can add or edit these entries.';
+  return (
+    <ThemeProvider theme={PONotesTableTheme}>
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Typography variant='h6'>
+          ACTION ITEMS
+          ({countOfItems})
+        </Typography>
+        {/* The information model displaying the information about Action Item is called here and information 
+      about Action items (heading, definition and accessibility information) are passed as props */}
+        <PONotesInformationModel heading={heading}
+          definition={definition}
+          accessibiltyInformation={accessibiltyInformation} />
+      </Box>
+    </ThemeProvider>
+  )
+}
+// props validation
+ActionItemsHeader.propTypes = {
+  countOfItems: PropTypes.number.isRequired
+}

--- a/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/AgendaItemsTableHeader.js
+++ b/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/AgendaItemsTableHeader.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Typography } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import PropTypes from 'prop-types';
+import PONotesInformationModel from './PONotesInformationModel'
+import PONotesTableTheme from '../../../Theme/globalTheme'
+
+export default function AgendaItemsTableHeader(props) {
+  // countOfItems is the number of items in the table
+  const { countOfItems } = props;
+  // heading is the heading of the information model
+  const heading = 'Agenda Items';
+  // definition is the definition of the information model
+  const definition = ' are the questions that the PO wanted to ask  the team members and the  leadership to derive some actions or decisions.'
+  // accessibiltyInformation is the accessibility information of the information model
+  const accessibiltyInformation = '  PO is the owner of this section only PO can add or edit these entries.';
+  return (
+    <ThemeProvider theme={PONotesTableTheme}>
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Typography variant='h6' >
+          AGENDA ITEMS
+          ({countOfItems})
+        </Typography>
+        {/* The information model displaying the information about Action Item is called here and information 
+      about Action items (heading, definition and accessibility information) are passed as props */}
+        <PONotesInformationModel heading={heading}
+          definition={definition}
+          accessibiltyInformation={accessibiltyInformation} />
+      </Box>
+    </ThemeProvider>
+  )
+}
+// props validation
+AgendaItemsTableHeader.propTypes = {
+  countOfItems: PropTypes.number.isRequired
+}

--- a/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/KeyDecisionsTableHeader.js
+++ b/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/KeyDecisionsTableHeader.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Typography } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import PropTypes from 'prop-types';
+import PONotesInformationModel from './PONotesInformationModel'
+import PONotesTableTheme from '../../../Theme/globalTheme'
+
+export default function KeyDecisionsHeader(props) {
+  // countOfItems is the number of items in the table
+  const { countOfItems } = props;
+  // heading is the heading of the information model
+  const heading = 'Key Decisions';
+  // definition is the definition of the information model
+  const definition = ' are the vital outcomes/decisions from the various discussions that PO has been part of.';
+  // accessibiltyInformation is the accessibility information of the information model
+  const accessibiltyInformation = '  PO is the owner of this section only PO can add or edit these entries.';
+  return (
+    <ThemeProvider theme={PONotesTableTheme}>
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Typography variant='h6' >
+          KEY DECISIONS
+          ({countOfItems})
+        </Typography>
+        {/* The information model displaying the information about Action Item is called here and information 
+      about Action items (heading, definition and accessibility information) are passed as props */}
+        <PONotesInformationModel heading={heading}
+          definition={definition}
+          accessibiltyInformation={accessibiltyInformation} />
+      </Box>
+    </ThemeProvider>
+  )
+}
+// props validation
+KeyDecisionsHeader.propTypes = {
+  countOfItems: PropTypes.number.isRequired
+}

--- a/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/PONotesInformationModel.js
+++ b/src/components/poNotesComponents/PONotesTables/PONotesTablesHeader/PONotesInformationModel.js
@@ -1,0 +1,78 @@
+import { React, useState } from 'react';
+import Box from '@mui/material/Box';
+import Modal from '@mui/material/Modal';
+import Button from '@mui/material/Button';
+import PropTypes from 'prop-types';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+
+const style = {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 400,
+    fontFamily: 'Roboto',
+    bgcolor: 'background.paper',
+    boxShadow: 24,
+    pt: 2,
+    px: 4,
+    pb: 3,
+};
+export default function NestedModal(props) {
+    // props destructuring
+    /* props contains values for heading, definition and accessibility information of the selected
+    PO notes type (Action item or Key decisions or Agenda items) */
+    const { heading, definition, accessibiltyInformation } = props;
+    const [open, setOpen] = useState(false);
+    // function to open the modal
+    const handleOpen = () => {
+        setOpen(true);
+    };
+    // function to close the modal
+    const handleClose = () => {
+        setOpen(false);
+    };
+    return (
+        <Box>
+            {/* Icon to open the modal */}
+            <InfoOutlinedIcon onClick={handleOpen} />
+
+            <Modal
+                open={open}
+                onClose={handleClose}
+                aria-labelledby="parent-modal-title"
+                aria-describedby="parent-modal-description"
+            >
+                {/* Modal content */}
+                <Box sx={{ ...style }} >
+
+                    {/** Heading of the PO notes type (Action item or Key decisions or Agenda items) */}
+                    <h2 id="parent-modal-title">
+                        {heading}
+                    </h2>
+                    {/** Definition of the PO notes type (Action item or Key decisions or Agenda items) */}
+                    <p id="parent-modal-description">
+                        <b>{heading}</b>{definition}
+                    </p>
+                    {/** Accessibility information of the (Action item or Key decisions or Agenda items) */}
+                    <p id="parent-modal-description">
+                        {accessibiltyInformation}
+                    </p>
+                    <Box sx={{
+                        display: 'flex',
+                        flexDirection: 'row-reverse'
+                    }}>
+                        {/* Button to close the modal */}
+                        <Button onClick={handleClose}>OK</Button>
+                    </Box>
+                </Box>
+            </Modal>
+        </Box>
+    );
+}
+// Props validation
+NestedModal.propTypes = {
+    heading: PropTypes.string.isRequired,
+    definition: PropTypes.string.isRequired,
+    accessibiltyInformation: PropTypes.string.isRequired
+}

--- a/src/components/poNotesComponents/poNotesBody.js
+++ b/src/components/poNotesComponents/poNotesBody.js
@@ -1,17 +1,14 @@
 import * as React from 'react';
-import CssBaseline from '@mui/material/CssBaseline';
-import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
+import PONotesGridLayout from './PONotesTables/PONotesGridLayout';
 
-const PoNotesBody = () => {
+export default function poNotesBody() {
   return (
-    <React.Fragment>
-      <CssBaseline />
-      <Container maxWidth="xl">
-        <Box sx={{ bgcolor: '#E6EEF2', height: '83.5vh' }} />
-      </Container>
-    </React.Fragment>
-  );
+    <Grid>
+      <Grid sx={{
+        minWidth: "100%",
+        height: "100vh", backgroundColor: '#F5F5F5'
+      }}><PONotesGridLayout /></Grid>
+    </Grid>
+  )
 }
-
-export default PoNotesBody;

--- a/src/components/routes/poNotes.js
+++ b/src/components/routes/poNotes.js
@@ -1,15 +1,14 @@
-import Navbar from '../dumbComponents/navBar'
+import React from 'react';
+import Box from '@mui/material/Box';
 import PoNotesBody from '../poNotesComponents/poNotesBody';
 import PoNotesHeader from '../poNotesComponents/poNotesHeader';
 
-const poNotesContainer = ()=>{
-    return (
-        <div>
-            <Navbar/>
-            <PoNotesHeader/>
-            <PoNotesBody/>
-        </div>
-    );
-};
 
-export default poNotesContainer;
+export default function PoNotesContainer() {
+  return (
+    <Box>
+      <Box sx={{ m: -2, p: 4 }}> <PoNotesHeader /> </Box>
+      <Box > <PoNotesBody /> </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
- Added tables for action items, key decisions and agenda items.
- Added model to display description about action items, key decisions and agenda items.
- Added functionality to display count of items present in each table.
- Added layout using grid to display the tables created.
- Created a global theme which consists of theme for PO notes tables.


 -Tables for action items, key decisions and agenda items are used to display action items, key decisions and agenda items created by PO .Model is used to display description about action items, key decisions and agenda items when the user clicks on the info icon on respective table header.


- Created table and created a global theme and reused the theme from it for all the 3 tables.
- Model for displaying description about respective PONotes type(action items, key decisions and agenda items) will be displayed once the user click on the info icon in the header of respective table.
- Layout has been created using grid to make the tables responsive.
- Count of items in each table is passed as props from respective tables.
- Added props validation for all props.


<img width="1792" alt="image" src="https://user-images.githubusercontent.com/122451790/216822594-b78025d7-70bb-4e4f-978d-6044b68d933b.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/122451790/216822622-71df4b18-00a3-437e-b05a-ad25bc0f4adc.png">

- I have followed the same code structure for all PONotes Tables (ActionItemsTable, KeyDecisionsTables and AgendaItemsTables).
- I have followed the same code structure for all PONotes Tables headers (ActionItemsTableHeader, KeyDecisionsTablesHeader and AgendaItemsTablesHeader).

