### PR TITLE
Fix/po notes dialog

### DIFF
--- a/src/components/poNotesComponents/PONotesDialog.js
+++ b/src/components/poNotesComponents/PONotesDialog.js
@@ -106,9 +106,9 @@ export default function PONotesDialog({ updateItem, data, open, handleClose }) {
       setError(val => val + err);
     }
     finally {
-      setLock(true);
+      setLock(()=>true);
       handleClose();
-      if (!updateItem) setStatement('')
+      if (!updateItem) setStatement(()=>'');
     }
   };
 

--- a/src/components/poNotesComponents/PONotesDialog.js
+++ b/src/components/poNotesComponents/PONotesDialog.js
@@ -92,7 +92,6 @@ export default function PONotesDialog({ updateItem, data, open, handleClose }) {
 
 
       if (updateItem) {
-        console.log(body);
         await axios.patch(`${DOMAIN}/api/po-notes/${data.noteId}`, body);
         const response = 'Note UPDATED successfully';
         setSuccess(() => response);


### PR DESCRIPTION
Issue: Earlier we couldn't add multiple notes through form as the form would get locked.
Solution: Used State queueing to resolve the issue.