### PR TITLE
feat: create generic modal to take input

### DIFF
--- a/src/components/dsm/Announcements.js
+++ b/src/components/dsm/Announcements.js
@@ -1,13 +1,25 @@
-import React, { useContext } from 'react';
-import { Grid, Accordion, AccordionSummary, AccordionDetails, Typography } from '@mui/material';
+import React, { useContext, useState } from 'react';
+import { Grid, Accordion, AccordionSummary, AccordionDetails, Typography, IconButton, Dialog } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { AddCircle as AddCircleIcon } from '@mui/icons-material';
 import { DSMBodyLayoutContext } from "../contexts/DSMBodyLayoutContext"
+import GenericInputModal from '../elements/dsm/GenericInputModal';
 
 export default function Announcements() {
   const { gridHeightState, dispatchGridHeight } = useContext(DSMBodyLayoutContext)
   const handleExpandAnnouncements = () => {
     dispatchGridHeight({ type: "ANNOUNCEMENT" })
   };
+
+  const [openModal, setOpenAddModal] = useState(false);
+  const handleAddButtonClick = () => {
+    setOpenAddModal(!openModal);
+    dispatchGridHeight({ type: "ANNOUNCEMENT" });
+  }
+
+  const handleModalClose = () => {
+    setOpenAddModal(false);
+  }
 
   return (
     <Grid item height={gridHeightState.announcement.height} >
@@ -18,10 +30,26 @@ export default function Announcements() {
           expandIcon={<ExpandMoreIcon />}
           aria-controls="panel4a-content"
           id="panel4a-header"
+          sx={{
+            '.MuiAccordionSummary-content': {
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              width: "100%",
+            }
+          }}
         >
-          {/* All Content/Development of Announcements HEADER goes here */}
           <Typography variant="dsmSubMain">Announcements</Typography>
+          <IconButton onClick={handleAddButtonClick}>
+            <AddCircleIcon color="primary" />
+          </IconButton>
         </AccordionSummary>
+        <Dialog
+          open={openModal}
+          onClose={handleModalClose}
+        >
+          <GenericInputModal title='Announcement' onCloseButtonClick={handleModalClose} primaryButtonText='Save' />
+        </Dialog>
         <AccordionDetails>
           {/* All Content/Development of Announcements BODY goes here */}
           <Typography>

--- a/src/components/dsm/Announcements.js
+++ b/src/components/dsm/Announcements.js
@@ -29,7 +29,6 @@ export default function Announcements() {
     setOpenAddModal(false);
   }
 
-  // TODO: integrate with backend
   // OPTIMIZE: Is backend for announcements paginated ?
   const getAnnouncements = async () =>{
     try {

--- a/src/components/dsm/Announcements.js
+++ b/src/components/dsm/Announcements.js
@@ -61,26 +61,3 @@ export default function Announcements() {
     </ Grid >
   );
 };
-
-// Announcements.propTypes = {
-//   gridHeightState: Proptypes.shape({
-//     sentiment: Proptypes.shape({
-//       expanded: Proptypes.bool.isRequired,
-//       height: Proptypes.number.isRequired,
-//     }).isRequired,
-//     celebration: Proptypes.shape({
-//       expanded: Proptypes.bool.isRequired,
-//       fullExpanded: Proptypes.bool.isRequired,
-//       height: Proptypes.number.isRequired,
-//     }).isRequired,
-//     request: Proptypes.shape({
-//       expanded: Proptypes.bool.isRequired,
-//       height: Proptypes.number.isRequired,
-//     }).isRequired,
-//     announcement: Proptypes.shape({
-//       expanded: Proptypes.bool.isRequired,
-//       height: Proptypes.number.isRequired,
-//     }).isRequired,
-//   }).isRequired,
-//   dispatchGridHeight: Proptypes.func.isRequired,
-// }

--- a/src/components/dsm/Announcements.js
+++ b/src/components/dsm/Announcements.js
@@ -1,9 +1,10 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Grid, Accordion, AccordionSummary, AccordionDetails, Typography, IconButton, Dialog } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { AddCircle as AddCircleIcon } from '@mui/icons-material';
 import { DSMBodyLayoutContext } from "../contexts/DSMBodyLayoutContext"
 import GenericInputModal from '../elements/dsm/GenericInputModal';
+import ChatContainer from '../elements/dsm/ChatContainer';
 
 export default function Announcements() {
   const { gridHeightState, dispatchGridHeight } = useContext(DSMBodyLayoutContext)
@@ -11,7 +12,7 @@ export default function Announcements() {
     dispatchGridHeight({ type: "ANNOUNCEMENT" })
   };
 
-
+  const [announcements, setAnnouncements] = useState([]);
   const [openModal, setOpenAddModal] = useState(false);
   const handleAddButtonClick = () => {
     setOpenAddModal(!openModal);
@@ -21,6 +22,33 @@ export default function Announcements() {
   const handleModalClose = () => {
     setOpenAddModal(false);
   }
+
+  // TODO: integrate with backend
+  // OPTIMIZE: Is backend for announcements paginated ?
+  const getAnnouncements = async () => [
+      {
+        "announcementId": 0,
+        "author": "Ritik Rajdev",
+        "content": "This is a test announcement",
+        "createdAt": "2023-02-20T20:35:20.327Z"
+      },
+      {
+        "announcementId": 1,
+        "author": "Ritik Rajdev",
+        "content": "This is a test announcement",
+        "createdAt": "2023-02-20T20:35:20.327Z"
+      }
+    ]
+
+  useEffect(() => {
+    getAnnouncements().then((_announcements) => {
+      setAnnouncements(_announcements);
+    })
+  }, [])
+
+  const handleChatClick = (announcement) => {
+    console.log(announcement);
+  };
 
   return (
     <Grid item height={gridHeightState.announcement.height} >
@@ -63,12 +91,22 @@ export default function Announcements() {
           />
           
         </Dialog>
-        <AccordionDetails>
-          {/* All Content/Development of Announcements BODY goes here */}
-          <Typography>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-            malesuada lacus ex, sit amet blandit leo lobortis eget.
-          </Typography>
+        <AccordionDetails sx={{
+          display: "flex",
+          flexDirection: "column",
+          padding: "16px",
+          gap: "16px",
+        }}>
+          {announcements.map((announcement) => (
+            <ChatContainer
+              key={announcement.announcementId}
+              name={announcement.author}
+              content={announcement.content}
+              date={new Date(announcement.createdAt)}
+              onClick={() => handleChatClick(announcement)}
+            />
+          ))}
+
         </AccordionDetails>
       </Accordion>
     </ Grid >

--- a/src/components/dsm/Announcements.js
+++ b/src/components/dsm/Announcements.js
@@ -55,12 +55,12 @@ export default function Announcements() {
 
   const addAnnouncementToDB = async (content) => {
     try {
-      await axios.post(`${DOMAIN}/api/dsm/announcements`, {
+      const res = await axios.post(`${DOMAIN}/api/dsm/announcements`, {
         content, 
       });
       setSuccess(() => "Announcement created successfully");
 
-      return true;
+      return res.data;
     }
     catch(err) {
       console.error(err);
@@ -101,9 +101,13 @@ export default function Announcements() {
             title='Announcement Statement'
             onCloseButtonClick={handleModalClose}
             primaryButtonText='Post'
-            onPrimaryButtonClick={(content) => {
-              if (addAnnouncementToDB(content))
+            onPrimaryButtonClick={async (content) => {
+              const newAnnouncement = await addAnnouncementToDB(content);
+              if (newAnnouncement) {
+                setAnnouncements(() => [newAnnouncement, ...announcements])
                 handleModalClose();
+              }
+
             }}
 
             // TODO: add children component to check for addition on slack channel

--- a/src/components/dsm/Announcements.js
+++ b/src/components/dsm/Announcements.js
@@ -11,6 +11,7 @@ export default function Announcements() {
     dispatchGridHeight({ type: "ANNOUNCEMENT" })
   };
 
+
   const [openModal, setOpenAddModal] = useState(false);
   const handleAddButtonClick = () => {
     setOpenAddModal(!openModal);
@@ -48,7 +49,19 @@ export default function Announcements() {
           open={openModal}
           onClose={handleModalClose}
         >
-          <GenericInputModal title='Announcement' onCloseButtonClick={handleModalClose} primaryButtonText='Save' />
+          <GenericInputModal
+            title='Announcement Statement'
+            onCloseButtonClick={handleModalClose}
+            primaryButtonText='Post'
+            primaryButtonOnClick={(content) => {
+              // eslint-disable-next-line no-unused-vars
+              const announcement = {content};
+              // TODO: add Announcement to DB
+            }}
+
+            // TODO: add children component to check for addition on slack channel
+          />
+          
         </Dialog>
         <AccordionDetails>
           {/* All Content/Development of Announcements BODY goes here */}

--- a/src/components/elements/dsm/ChatContainer.js
+++ b/src/components/elements/dsm/ChatContainer.js
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Box } from "@mui/system";
+import { Avatar, Typography } from "@mui/material";
+import stc from "string-to-color";
+
+export default function ChatContainer({ name, src, content, date, onClick }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        gap: "8px",
+      }}
+      onClick={onClick}
+    >
+      <Avatar src={src} sx={{ bgcolor: stc(name) }}>
+        {src ? "" : name.trim()[0]}
+      </Avatar>
+      <Box>
+        <Typography>{content}</Typography>
+        <Typography variant="caption" sx={{marginTop: 8, color: 'gray'}}>
+          {date.toLocaleString("en-US", {
+            month: "short",
+            day: "numeric",
+          })}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+ChatContainer.propTypes = {
+  name: PropTypes.string,
+  src: PropTypes.string,
+  content: PropTypes.string,
+  date: PropTypes.instanceOf(Date),
+  onClick: PropTypes.func,
+};
+
+ChatContainer.defaultProps = {
+  name: "",
+  src: undefined,
+  content: "",
+  date: "",
+  onClick: () => {},
+};

--- a/src/components/elements/dsm/GenericInputModal.js
+++ b/src/components/elements/dsm/GenericInputModal.js
@@ -1,0 +1,132 @@
+import { Close as CloseIcon } from "@mui/icons-material";
+import { Button, IconButton, TextField, Typography } from "@mui/material";
+import { Box } from "@mui/system";
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+
+export default function GenericInputModal({
+  onCloseButtonClick,
+
+  title,
+
+  defaultValue,
+
+  children,
+
+  primaryButtonText,
+  onPrimaryButtonClick,
+
+  secondaryButtonText,
+  onSecondaryButtonClick,
+
+  placeholder,
+}) {
+  const [content, setContent] = useState(defaultValue ?? "");
+
+  return (
+    <Box
+      sx={{
+        width: "max(25vw, 340px)",
+        boxSizing: "border-box",
+        backgroundColor: "#FFFFFF",
+        boxShadow: "0px 30px 60px rgba(32, 56, 85, 0.15)",
+        borderRadius: "8px",
+        padding: "16px 24px 24px 24px",
+      }}
+    >
+      {/* Action Buttons */}
+      {/* TODO: add editable buttons and actions as well */}
+      <Box
+        sx={{
+          textAlign: "right",
+        }}
+      >
+        <IconButton onClick={onCloseButtonClick}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+
+      {/* Title */}
+      <Typography variant="h5">{title}</Typography>
+
+      {/* TextField */}
+      <TextField
+        sx={{
+          width: "100%",
+          margin: "16px 0",
+          boxShadow: "0px 5px 15px rgba(119, 132, 238, 0.3)",
+        }}
+        value={content}
+        multiline
+        rows={4}
+        placeholder={placeholder}
+        onChange={(e) => setContent(e.target.value)}
+      />
+
+      {children}
+
+      {/* Primary Button */}
+      <Button
+        sx={{
+          margin: "16px 0",
+          padding: "12px 0",
+          width: "100%",
+          borderRadius: "8px",
+          color: "customButton1.contrastText",
+          backgroundColor: "customButton1.main",
+          "&:hover": {
+            color: "customButton1.contrastText",
+            backgroundColor: "customButton1.main",
+          },
+        }}
+        onClick={() => onPrimaryButtonClick(content)}
+      >
+        {primaryButtonText}
+      </Button>
+
+      {secondaryButtonText && (
+        <Button
+          sx={{
+            padding: "12px 0",
+            width: "100%",
+            borderRadius: "8px",
+            color: "secondaryButton.contrastText",
+            backgroundColor: "secondaryButton.main",
+            "&:hover": {
+              color: "secondaryButton.contrastText",
+              backgroundColor: "secondaryButton.main",
+            },
+          }}
+          onClick={() => onSecondaryButtonClick(content)}
+        >
+          {secondaryButtonText}
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+GenericInputModal.propTypes = {
+  onCloseButtonClick: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  primaryButtonText: PropTypes.string.isRequired,
+  onPrimaryButtonClick: PropTypes.func,
+  children: PropTypes.node,
+  placeholder: PropTypes.string,
+  defaultValue: PropTypes.string,
+  secondaryButtonText: PropTypes.string,
+  onSecondaryButtonClick: PropTypes.func,
+};
+
+GenericInputModal.defaultProps = {
+  onPrimaryButtonClick: (content) => {
+    console.log(content);
+  },
+  onSecondaryButtonClick: (content) => {
+    console.log(content);
+  },
+  secondaryButtonText: undefined,
+  children: undefined,
+  placeholder: undefined,
+  defaultValue: undefined,
+};

--- a/src/components/elements/dsm/GenericInputModal.js
+++ b/src/components/elements/dsm/GenericInputModal.js
@@ -41,7 +41,7 @@ export default function GenericInputModal({
           textAlign: "right",
         }}
       >
-        <IconButton onClick={onCloseButtonClick}>
+        <IconButton onClick={() => onCloseButtonClick(content)}>
           <CloseIcon />
         </IconButton>
       </Box>

--- a/src/components/elements/dsm/GenericInputModal.js
+++ b/src/components/elements/dsm/GenericInputModal.js
@@ -32,6 +32,7 @@ export default function GenericInputModal({
         boxShadow: "0px 30px 60px rgba(32, 56, 85, 0.15)",
         borderRadius: "8px",
         padding: "16px 24px 24px 24px",
+        position: "relative"
       }}
     >
       {/* Action Buttons */}

--- a/src/components/theme/GlobalTheme.js
+++ b/src/components/theme/GlobalTheme.js
@@ -35,6 +35,10 @@ const theme = createTheme({
     },
     backgroundColor: {
       main: '#e6eef2',
+    },
+    secondaryButton: {
+      main: '#EEF2F5',
+      contrastText: '#000',
     }
   },
   components: {


### PR DESCRIPTION
* Creation of add icon to open modal
<img width="528" alt="image" src="https://user-images.githubusercontent.com/56875929/220190392-f17dd431-d551-44b0-ab76-5c53cf33a4f1.png">

* Creation of generic modal to get input from user
<img width="528" alt="image" src="https://user-images.githubusercontent.com/56875929/220190531-f5c32b01-5684-48d6-abc3-13749afb3c2e.png">

* extensible enought to create secondary button for next requirements
<img width="528" alt="image" src="https://user-images.githubusercontent.com/56875929/220190751-c8a00693-eac5-4592-90fd-5326dea6f709.png">

* extensible to add further inputs using children nodes
<img width="528" alt="image" src="https://user-images.githubusercontent.com/56875929/220190927-2aadef79-fe4f-46b7-b7a7-27f6302b39e9.png">

* add read functionality to each of the announcements
<img width="528" alt="image" src="https://user-images.githubusercontent.com/56875929/220199902-942f4e9e-dabd-4e69-ac2b-905f42f05f8e.png">


