### PR TITLE
fix: dialog size

### DIFF
--- a/src/components/elements/RichTextArea.js
+++ b/src/components/elements/RichTextArea.js
@@ -7,6 +7,7 @@ import ReactTextareaAutocomplete from '@webscopeio/react-textarea-autocomplete';
 import Proptypes from 'prop-types';
 import { getAllMembersData } from '../utilityFunctions/User';
 import { ProjectUserContext } from '../contexts/ProjectUserContext';
+import { ErrorContext } from '../contexts/ErrorContext';
 
 function Loading() {
   return <Box>Loading...</Box>;
@@ -29,6 +30,7 @@ export default function RichTextArea({ value, placeholder, setContent, sx, disab
 
   const [users, setUsers] = useState([]);
   const { projectDetails } = useContext(ProjectUserContext);
+  const { setError } = useContext(ErrorContext);
 
   useEffect(() => {
     setUsers(getAllMembersData(projectDetails?.projectMembers ?? []));
@@ -38,6 +40,15 @@ export default function RichTextArea({ value, placeholder, setContent, sx, disab
     const similarUsers = users.filter((user) => user.email.toLowerCase().includes(text.toLowerCase()));
     return similarUsers.map((user) => ({ name: user.email, char: '@' }));
   }
+
+  const handleChangeTextArea = (e) => {
+    if(e.target.value.length > 300)
+    {
+      setError("You can't write more than 300 characters");
+      return;
+    }
+    setContent(e.target.value);
+  };
 
   return (
     <ReactTextareaAutocomplete
@@ -57,13 +68,14 @@ export default function RichTextArea({ value, placeholder, setContent, sx, disab
         padding: '15px 20px',
         height: '100px',
         borderRadius: '8px',
+        resize: 'none',
         ...sx,
       }}
       containerStyle={{
         margin: '5px auto'
       }}
       minChar={0}
-      onChange={(e) => setContent(e.target.value)}
+      onChange={(e) => handleChangeTextArea(e)}
       trigger={{
         ':': {
           dataProvider: token => emoji(token)

--- a/src/components/elements/dsm/GenericInputModal.js
+++ b/src/components/elements/dsm/GenericInputModal.js
@@ -61,6 +61,15 @@ export default function GenericInputModal({
     return similarUsers.map((user) => ({ name: user.email, char: '@' }));
   }
 
+  const handleChangeTextArea = (e) => {
+    if(e.target.value.length > 300)
+    {
+      setError("You can't write more than 300 characters");
+      return;
+    }
+    setContent(e.target.value);
+  }
+
   return (
     <Box
       sx={matchesLargeSize ? {
@@ -146,20 +155,24 @@ export default function GenericInputModal({
             boxShadow: '0px 5px 15px rgba(119, 132, 238, 0.3)',
             multiline: true,
             rows: 4,
+            borderRadius: '8px',
             fontSize: '16px',
             lineHeight: '20px',
             height: '130px',
             fontFamily: 'Roboto, sans-serif',
+            resize: 'none'
           } : {
             width: '80%',
             padding: '20px',
             boxShadow: '0px 5px 15px rgba(119, 132, 238, 0.3)',
+            borderRadius: '8px',
             multiline: true,
             rows: 4,
             fontSize: '16px',
             lineHeight: '20px',
             height: '130px',
             fontFamily: 'Roboto, sans-serif',
+            resize: 'none'
           }}
           containerStyle={{
             width: '100%',
@@ -186,7 +199,7 @@ export default function GenericInputModal({
           value={content}
           rows={4}
           placeholder={placeholder}
-          onChange={(e) => setContent(e.target.value)}
+          onChange={(e) => handleChangeTextArea(e)}
           disabled={isDisabled}
         />
       </Box>

--- a/src/components/poNotesComponents/PONotesDialog.js
+++ b/src/components/poNotesComponents/PONotesDialog.js
@@ -212,9 +212,9 @@ export default function PONotesDialog({ updateItem, data, open, handleClose, acc
             PO Note Type
           </Typography>
           <List>
-            <ListItem>
-              <Box sx={{ flexGrow: 0.2, display: { md: 'flex' } }}>
-                <FormControl sx={{ minWidth: 200 }} size="small">
+            <ListItem sx={{display: 'flex'}}>
+              <Box sx={{ display: { md: 'flex' }, flexGrow: 1 }}>
+                <FormControl sx={{ flexGrow: 1, width: '100%'}} size="small">
                   <InputLabel id="demo-select-small-2">Note Type</InputLabel>
                   <Select
                     data-testid="noteTypeSelect"


### PR DESCRIPTION
* The text-area is now not resizable.
* The width of note type in PO notes is now fixed.
* The size of content is now limited 300 characters.
<img width="1792" alt="Screenshot 2023-03-27 at 6 00 14 PM" src="https://user-images.githubusercontent.com/53441820/228143416-d63f52f0-4d1a-4ade-91b0-51224a577722.png">
<img width="425" alt="Screenshot 2023-03-27 at 6 00 05 PM" src="https://user-images.githubusercontent.com/53441820/228143426-984eabf6-6eff-4142-acba-ae35f3885d4a.png">
